### PR TITLE
FIX2 MYPAGE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,4 @@ gem 'haml-rails'
 gem 'erb2haml'
 gem 'font-awesome-rails'
 gem 'jquery-rails'
+gem 'rails_12factor', group: :production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (5.2.4.1)
       actionpack (= 5.2.4.1)
       activesupport (= 5.2.4.1)
@@ -248,6 +253,7 @@ DEPENDENCIES
   pg
   puma (~> 3.11)
   rails (~> 5.2.4)
+  rails_12factor
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
     def show
-        @user = User.find_by(id: params[:id])
         @books = current_user.books
         @nickname = current_user.nickname
     end


### PR DESCRIPTION
# WHAT
マイページを修正する

# WHY
デプロイ時にエラーが出るため

# HOW
heroku run rails db:migrate:resetコマンドでのエラーが発生していた。
本番環境特有の削除系コマンドの誤操作を防止する機能が動作していたのが原因だった。
rails経由ではなく、直接PostgreSQLにアクセスするheroku pg:reset DATABASE_URLコマンドを実行し、heroku run rails db:migrateを実行し、解決。